### PR TITLE
Move Statics.editorStartContentUrl into Editor.js and fix dependency declarations

### DIFF
--- a/app/Global.js
+++ b/app/Global.js
@@ -53,6 +53,8 @@ Ext.define('LIME.Global', {
     alternateClassName : 'Config',
     uxPath : 'LIME.ux',
 
+    requires : ["LIME.Utilities", "LIME.Statics"],
+
     extensionScripts : ['LoadPlugin', 'Language', 'SavePlugin', 'TranslatePlugin'],
 
     language : 'default',

--- a/app/Statics.js
+++ b/app/Statics.js
@@ -59,11 +59,6 @@ Ext.define('LIME.Statics', {
 	 * The path of global pattern configuration file 
 	 */
 	globalPatternsFile : "config/Patterns.json",
-	/**
-	 * @property {String} editorStartContentUrl
-	 * The path of default editor content file 
-	 */
-	editorStartContentUrl : 'config/examples/editorStartContent-'+Locale.getLang()+'.html',
 	
 	/**
 	 * Static values for metadata

--- a/app/Utilities.js
+++ b/app/Utilities.js
@@ -53,6 +53,8 @@ Ext.define('LIME.Utilities', {
 	/* Since this is merely a utility class define it as a singleton (static members by default) */
 	singleton : true,
 	alternateClassName : 'Utilities',	
+
+	requires : ["LIME.Statics"],
 	
 	/**
 	 * @property {String} buttonFieldDefault

--- a/app/controller/Editor.js
+++ b/app/controller/Editor.js
@@ -1027,7 +1027,7 @@ Ext.define('LIME.controller.Editor', {
             });*/
 
     		Ext.Ajax.request({
-    			url : Statics.editorStartContentUrl,
+    			url : editor.getEditorStartContentUrl(),
     			success : function(response) {
     				var animation = mainToolbarController.highlightFileMenu();
                     // Create a window containing the example document and highlight the file menu
@@ -1541,5 +1541,12 @@ Ext.define('LIME.controller.Editor', {
 				}
 			}
 		});
+	},
+
+	/**
+	 * The path of default editor content file 
+	 */
+	getEditorStartContentUrl : function() {
+	    return 'config/examples/editorStartContent-'+Locale.getLang()+'.html';
 	}
 });


### PR DESCRIPTION
This fixes ambiguous load orders for Utilities, Globals, Statics and
Lang and makes them explicit. To prevent a circular reference, move
editorStartContentUrl into app/Editor.js since it isn't actually
static.

This means that we can load something other than 'default' as the
default language when the editor first starts up without failing
on Utilities and other dependencies not having been loaded.
