### PR TITLE
Adding missing document types in Uri.js doc-type Uri component validator

### DIFF
--- a/packages/akn-main/src/Uri.js
+++ b/packages/akn-main/src/Uri.js
@@ -191,7 +191,12 @@ Ext.define('AknMain.Uri', {
                 'doc',
                 'act',
                 'bill',
-                'debaterecord',
+                'debate',
+                'debateReport',
+                'statement',
+                'judgment',
+                'portion',
+                'officialGazette',
                 'documentCollection'
             ].indexOf(item) !== -1;
         },


### PR DESCRIPTION
Some of the AN document types are missing in the validation check for the doc-type URI component. 

These have been added, and should fix Issue #24
