### PR TITLE
 Fixed duplication of main component name in URI problem : see Issue #27

### DIFF
--- a/packages/akn-main/src/Uri.js
+++ b/packages/akn-main/src/Uri.js
@@ -97,7 +97,7 @@ Ext.define('AknMain.Uri', {
         uri.work = this.uriFunctions.work.bind(uri),
         uri.expression = this.uriFunctions.expression.bind(uri),
         uri.manifestation = this.uriFunctions.manifestation.bind(uri),
-        uri.item = this.uriFunctions.item.bind(uri)
+        uri.item = this.uriFunctions.item.bind(uri);
         return uri;
     },
 
@@ -239,9 +239,17 @@ Ext.define('AknMain.Uri', {
                    ((this.component && !hideComponent) ? '/' + this.component : '');
         },
 
-        manifestation: function () {
+        /**
+         * If forFrbrUri is set to true returns with as should be set for FRBRthis in FRBRmanifestation
+         *  else if set to false returns with as should be set for FRBRuri in FRBRmanifestation (i.e.
+         *  with .akn instead of .xml )
+         * @param forFrbrUri
+         * @returns {string}
+         */
+        manifestation: function (forFrbrUri) {
             return this.expression(true) +
-                   '/' + this.component + '.' + this.media;
+                '/' + this.component + '.' +
+                (!forFrbrUri ? this.media: 'akn' );
         },
 
         item: function () {

--- a/packages/akn-main/src/metadata/HtmlSerializer.js
+++ b/packages/akn-main/src/metadata/HtmlSerializer.js
@@ -58,8 +58,8 @@ Ext.define('AknMain.metadata.HtmlSerializer', {
         // identification
         '   <div class="identification" source="#{source}">',
         '       <div class="FRBRWork">',
-        '           <div class="FRBRthis" value="{uri.work}/main"/>',
-        '           <div class="FRBRuri" value="{uri.work}"/>',
+        '           <div class="FRBRthis" value="{uri.work}"/>',
+        '           <div class="FRBRuri" value="{uri.workUri}"/>',
         '<tpl for="aliases"><tpl if="level==\'work\'">' +
         '           <div class="FRBRalias" value="{value}" name="{name}"/>',
         '</tpl></tpl>' +
@@ -68,8 +68,8 @@ Ext.define('AknMain.metadata.HtmlSerializer', {
         '           <div class="FRBRcountry" value="{country}"/>',
         '       </div>',
         '       <div class="FRBRExpression">',
-        '          <div class="FRBRthis" value="{uri.expression}/main"/>',
-        '          <div class="FRBRuri" value="{uri.expression}"/>',
+        '          <div class="FRBRthis" value="{uri.expression}"/>',
+        '          <div class="FRBRuri" value="{uri.expressionUri}"/>',
         '<tpl for="aliases"><tpl if="level==\'expression\'">' +
         '           <div class="FRBRalias" value="{value}" name="{name}"/>',
         '</tpl></tpl>' +
@@ -78,8 +78,8 @@ Ext.define('AknMain.metadata.HtmlSerializer', {
         '          <div class="FRBRlanguage" language="{language}"/>',
         '       </div>',
         '       <div class="FRBRManifestation">',
-        '           <div class="FRBRthis" value="{uri.manifestation}/main"/>',
-        '           <div class="FRBRuri" value="{uri.manifestation}"/>',
+        '           <div class="FRBRthis" value="{uri.manifestation}"/>',
+        '           <div class="FRBRuri" value="{uri.manifestationUri}"/>',
         '<tpl for="aliases"><tpl if="level==\'manifestation\'">' +
         '           <div class="FRBRalias" value="{value}" name="{name}"/>',
         '</tpl></tpl>' +
@@ -222,8 +222,11 @@ Ext.define('AknMain.metadata.HtmlSerializer', {
         var uri = model.getUri();
         data.uri = {
             work: uri.work(),
+            workUri: uri.work(true),
             expression: uri.expression(),
-            manifestation: uri.manifestation()
+            expressionUri: uri.expression(true),
+            manifestation: uri.manifestation(),
+            manifestationUri: uri.manifestation(true)
         };
 
         return this.applyTemplate(data);


### PR DESCRIPTION
This pull request fixes the duplication of the "part" component in the URI reported in Issue #27 
